### PR TITLE
Added optional connectivity check to entrypoint

### DIFF
--- a/bin/connectivity-check
+++ b/bin/connectivity-check
@@ -1,0 +1,21 @@
+#!/bin/bash
+[[ -v VERBOSE ]] && set -x
+set -eu
+
+readonly connectivity_check_url="${1?argument 1 (connectivity_check_url) is required}"
+
+args=()
+if [[ -v VERBOSE ]]; then
+    args+=(-v)
+fi
+
+curl \
+    --connect-timeout 1 \
+    --max-time 1 \
+    --retry "${CONNECTIVITY_CHECK_RETRY_COUNT:-5}" \
+    --retry-delay 0 \
+    --retry-max-time "${CONNECTIVITY_CHECK_RETRY_MAX_TIME:-60}" \
+    -o /dev/null \
+    -s \
+    "${args[@]}" \
+    "${connectivity_check_url}" 2>&1

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -4,6 +4,10 @@ set -eu
 
 bootstrap-configs
 
+if [[ -v CONNECTIVITY_CHECK_URL ]]; then
+    connectivity-check "${CONNECTIVITY_CHECK_URL}"
+fi
+
 cmd=()
 # to make sure shell form doesn't break we need to manually iterate
 # over args to avoid subsplitting during the assignment


### PR DESCRIPTION
This PR add an optional connectivity check to the default entrypoint. This check can be used to to ensure that a service will be started after a http endpoint is reachable. We have this use case in kubernetes with an active istio proxy, as an example.

Examples: 

```sh
root@7b30f32d51ec:/srv# CONNECTIVITY_CHECK_URL=http://google.de entrypoint
root@7b30f32d51ec:/srv# echo $?
0
```

```sh
root@7b30f32d51ec:/srv# CONNECTIVITY_CHECK_URL=http://foo.bar entrypoint
root@7b30f32d51ec:/srv# echo $?
6
```