### PR TITLE
add libzip-dev dependency

### DIFF
--- a/stretch-php7-build.Dockerfile
+++ b/stretch-php7-build.Dockerfile
@@ -25,6 +25,7 @@ RUN apt-install \
     libssl-dev \
     libtool \
     libxml2-dev \
+    libzip-dev \
     make \
     pkg-config \
     re2c \


### PR DESCRIPTION
required for php 7.3 builds